### PR TITLE
Hotfix: Session base_url method undefined client error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    idrac (0.7.6)
+    idrac (0.7.7)
       activesupport (>= 6.0, < 8.1)
       base64 (~> 0.1, >= 0.1.0)
       colorize (~> 1.1, >= 1.1.0)

--- a/README.md
+++ b/README.md
@@ -218,6 +218,10 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Changelog
 
+### Version 0.7.7
+- **Bug Fix**: Fixed Session base_url method to use instance variables instead of client delegation
+- Resolved "undefined local variable or method 'client'" error in session.rb
+
 ### Version 0.7.6
 - **PR Preparation**: Updated version for PR submission
 

--- a/lib/idrac/session.rb
+++ b/lib/idrac/session.rb
@@ -282,7 +282,8 @@ module IDRAC
     private
 
     def base_url
-      client.base_url
+      protocol = use_ssl ? 'https' : 'http'
+      "#{protocol}://#{host}:#{port}"
     end
     
     def print_connection_debug_info

--- a/lib/idrac/version.rb
+++ b/lib/idrac/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IDRAC
-  VERSION = "0.7.6"
+  VERSION = "0.7.7"
 end


### PR DESCRIPTION
## Problem

After the duplicate method consolidation in #6, users are experiencing this error:

```
ssh_tunnel: Error: [NameError] undefined local variable or method 'client' for an instance of IDRAC::Session
/Users/jonathan/.rvm/gems/ruby-3.3.8/gems/idrac-0.7.6/lib/idrac/session.rb:285:in 'base_url'
```

## Root Cause

The Session class was trying to call `client.base_url` but the Session class doesn't have a `client` method - it has a `@client` instance variable. However, since the Session class already has `attr_reader :host, :port, :use_ssl`, it's better to build the base_url directly.

## Solution

- Fixed Session#base_url to use instance variables directly instead of delegating to client
- This makes the Session class more self-contained and eliminates the dependency
- Updated version to 0.7.7 and added changelog entry

## Testing

- All 28 tests still pass
- Resolves the NameError issue reported by users

## Changes

- Fixed `lib/idrac/session.rb` base_url method
- Version bump from 0.7.6 → 0.7.7  
- Updated changelog in README.md