### PR TITLE
Fix iDRAC8 false-positive virtual-media 'inserted' (VRM0009 eject 500)

### DIFF
--- a/lib/idrac/version.rb
+++ b/lib/idrac/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IDRAC
-  VERSION = "0.10.0"
+  VERSION = "0.10.1"
 end

--- a/lib/idrac/virtual_media.rb
+++ b/lib/idrac/virtual_media.rb
@@ -12,11 +12,18 @@ module IDRAC
           data = JSON.parse(response.body)
           
           media = data["Members"].map do |m|
-            # Check if media is inserted based on multiple indicators
-            is_inserted = m["Inserted"] || 
-                          (!m["Image"].nil? && !m["Image"].empty?) || 
-                          (m["ConnectedVia"] && m["ConnectedVia"] != "NotConnected") ||
-                          (m["ImageName"] && !m["ImageName"].empty?)
+            # Trust the BMC's structured connection state when present; fall back to the
+            # Image/ImageName string only when it isn't. On iDRAC8 a slot can keep a stale
+            # Image string with nothing actually mounted (ConnectedVia == "NotConnected" /
+            # Inserted == false); treating that as "inserted" makes eject POST an EjectMedia
+            # the BMC rejects with HTTP 500 (VRM0009).
+            is_inserted = if !m["Inserted"].nil?
+                            m["Inserted"]
+                          elsif m["ConnectedVia"]
+                            m["ConnectedVia"] != "NotConnected"
+                          else
+                            (m["Image"] && !m["Image"].empty?) || (m["ImageName"] && !m["ImageName"].empty?)
+                          end
               
             # Indicate which field is used for this iDRAC version and print it
             puts "ImageName is used for this iDRAC version".yellow if m["ImageName"]
@@ -70,13 +77,21 @@ module IDRAC
               "Managers/iDRAC.Embedded.1/VirtualMedia/#{device}/Actions/VirtualMedia.EjectMedia"
              end
       
-      response = authenticated_request(
-        :post,
-        "/redfish/v1/#{path}",
-        body: {}.to_json
-      )
-
-      response.status.between?(200, 299)
+      begin
+        response = authenticated_request(
+          :post,
+          "/redfish/v1/#{path}",
+          body: {}.to_json
+        )
+        response.status.between?(200, 299)
+      rescue IDRAC::Error => e
+        # iDRAC8 can still 500 with VRM0009 ("No Virtual Media devices are currently connected")
+        # when the slot reported a stale image but nothing was actually mounted. Ejecting nothing
+        # is a no-op success for callers, so swallow exactly that rejection.
+        raise unless e.message =~ /VRM0009|No Virtual Media devices are currently connected/i
+        puts "Nothing actually mounted on #{device}; treating eject as no-op".yellow
+        false
+      end
     end
 
     # Insert virtual media (ISO)

--- a/spec/virtual_media_spec.rb
+++ b/spec/virtual_media_spec.rb
@@ -1,0 +1,80 @@
+require "spec_helper"
+
+RSpec.describe IDRAC::VirtualMedia do
+  # Bare consumer of just the VirtualMedia module, matching the style of the other specs.
+  let(:client) { Class.new { include IDRAC::VirtualMedia }.new }
+
+  def media_response(members)
+    double(status: 200, body: { "Members" => members }.to_json)
+  end
+
+  describe "#virtual_media :inserted heuristic" do
+    it "does NOT treat a stale Image string as inserted when the slot is NotConnected (iDRAC8)" do
+      allow(client).to receive(:authenticated_request).and_return(
+        media_response([
+          { "Id" => "CD", "Name" => "Virtual CD",
+            "Inserted" => false, "ConnectedVia" => "NotConnected",
+            "Image" => "http://old-server/stale.iso" }
+        ])
+      )
+      cd = client.virtual_media.find { |m| m[:device] == "CD" }
+      expect(cd[:inserted]).to be(false)
+    end
+
+    it "treats a slot as inserted when the BMC reports it connected" do
+      allow(client).to receive(:authenticated_request).and_return(
+        media_response([
+          { "Id" => "CD", "Name" => "Virtual CD",
+            "Inserted" => true, "ConnectedVia" => "URI",
+            "Image" => "http://server/ubuntu.iso" }
+        ])
+      )
+      expect(client.virtual_media.first[:inserted]).to be(true)
+    end
+
+    it "falls back to the image string only when neither Inserted nor ConnectedVia is present" do
+      allow(client).to receive(:authenticated_request).and_return(
+        media_response([
+          { "Id" => "CD", "Name" => "Virtual CD", "ImageName" => "ubuntu.iso" }
+        ])
+      )
+      expect(client.virtual_media.first[:inserted]).to be_truthy
+    end
+  end
+
+  describe "#eject_virtual_media" do
+    let(:stale) do
+      { "Id" => "CD", "Name" => "Virtual CD",
+        "Inserted" => false, "ConnectedVia" => "NotConnected",
+        "Image" => "http://old-server/stale.iso" }
+    end
+    let(:mounted) do
+      { "Id" => "CD", "Name" => "Virtual CD",
+        "Inserted" => true, "ConnectedVia" => "URI", "Image" => "http://server/x.iso" }
+    end
+
+    it "does not POST an eject for a stale-but-unmounted slot" do
+      allow(client).to receive(:authenticated_request) do |method, *_|
+        raise "unexpected eject POST" if method == :post
+        media_response([stale])
+      end
+      expect(client.eject_virtual_media(device: "CD")).to be(false)
+    end
+
+    it "swallows a benign VRM0009 500 as a no-op success" do
+      allow(client).to receive(:authenticated_request) do |method, *_|
+        raise IDRAC::Error, "Failed with status 500: No Virtual Media devices are currently connected (IDRAC.2.9.VRM0009)" if method == :post
+        media_response([mounted])
+      end
+      expect(client.eject_virtual_media(device: "CD")).to be(false)
+    end
+
+    it "re-raises a non-benign eject error" do
+      allow(client).to receive(:authenticated_request) do |method, *_|
+        raise IDRAC::Error, "Failed with status 500: Internal Server Error" if method == :post
+        media_response([mounted])
+      end
+      expect { client.eject_virtual_media(device: "CD") }.to raise_error(IDRAC::Error, /Internal Server Error/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Fix iDRAC8 reinstalls aborting on a benign virtual-media eject (HTTP 500 **VRM0009**).

## Problem
`virtual_media`'s `:inserted` heuristic marked a slot inserted whenever `Image`/`ImageName` was non-empty:
```ruby
is_inserted = m["Inserted"] || (!m["Image"].nil? && !m["Image"].empty?) || ...
```
On iDRAC8 a slot can retain a **stale image string with nothing actually mounted** (`ConnectedVia == "NotConnected"`). So `eject_virtual_media` thought there was media, POSTed an `EjectMedia`, and the BMC rejected it with HTTP 500 `VRM0009 "No Virtual Media devices are currently connected"` — aborting the reinstall flow. (The consuming app was working around this with a global monkey-patch initializer.)

## Fix
- **Trust the BMC's structured state first**: use `Inserted` when present, else `ConnectedVia != "NotConnected"`, falling back to the image string only when neither is provided. This makes `eject_virtual_media`'s existing "nothing to eject" guard short-circuit instead of POSTing.
- **Defensively swallow a benign `VRM0009`** in `eject_virtual_media` as a no-op success, in case some firmware still misreports.
- Adds `spec/virtual_media_spec.rb`.
- Bumps `0.10.0` → `0.10.1`.

## Tests
- New spec: **6 examples, 0 failures** (stale slot → no POST; VRM0009 → swallowed; real error → re-raised).
- Note: `power_spec.rb` has 2 **pre-existing, unrelated** failures (`undefined method 'ensure_authenticated!'` — a stale bare-class mock); not touched here.
