### PR TITLE
Match firmware DUPs by Dell componentID, not display name

### DIFF
--- a/lib/idrac/firmware.rb
+++ b/lib/idrac/firmware.rb
@@ -86,9 +86,16 @@ module IDRAC
             
             if component_response.status == 200
               component_data = JSON.parse(component_response.body)
+              # Dell componentID — prefer the Oem field, else parse the inventory
+              # Id ("Installed-<componentID>-<version>"). Used to match DUPs by
+              # componentID rather than by ambiguous display name.
+              fw_id = component_data['Id'].to_s
+              component_id = component_data.dig('Oem', 'Dell', 'DellSoftwareInventory', 'ComponentID')
+              component_id ||= fw_id[/\A(?:Installed|Current|Previous|Available)-(\d+)-/, 1]
               firmware_inventory << {
                 name: component_data['Name'],
                 id: component_data['Id'],
+                component_id: component_id,
                 version: component_data['Version'],
                 updateable: component_data['Updateable'] || false,
                 status: component_data['Status'] ? component_data['Status']['State'] : 'Unknown'
@@ -168,25 +175,16 @@ module IDRAC
         next if displayed_components.include?(firmware_name.downcase)
         displayed_components.add(firmware_name.downcase)
         
-        # Extract key identifiers from the firmware name
-        identifiers = catalog.extract_identifiers(firmware_name)
-        
-        # Try to find a matching update
-        matching_updates = catalog_updates.select do |update|
-          update_name = update[:name] || ""
-          
-          # Check if any of our identifiers match the update name
-          identifiers.any? { |id| update_name.downcase.include?(id.downcase) } ||
-          # Or if the update name contains the firmware name
-          update_name.downcase.include?(firmware_name.downcase) ||
-          # Or if the firmware name contains the update name
-          firmware_name.downcase.include?(update_name.downcase)
-        end
-        
+        # Match the installed component to catalog DUPs. Prefer the Dell
+        # componentID (reliable) — only fall back to the legacy name heuristic
+        # when the inventory doesn't expose one.
+        matching_updates = catalog.updates_for_component(catalog_updates, fw)
+
         if matching_updates.any?
-          # Use the first matching update
-          update = matching_updates.first
-          
+          # Among matches, take the newest available version (the catalog can
+          # list several revisions for one component).
+          update = matching_updates.max_by { |u| catalog.version_key(u[:version]) }
+
           # Check if version is newer
           needs_update = catalog.compare_versions(fw[:version], update[:version])
           
@@ -253,12 +251,7 @@ module IDRAC
         
         # Skip if this update was already matched to a current firmware
         next if inventory[:firmware].any? do |fw|
-          firmware_name = fw[:name] || ""
-          identifiers = catalog.extract_identifiers(firmware_name)
-          
-          identifiers.any? { |id| update_name.downcase.include?(id.downcase) } ||
-          update_name.downcase.include?(firmware_name.downcase) ||
-          firmware_name.downcase.include?(update_name.downcase)
+          catalog.updates_for_component([update], fw).any?
         end
         
         puts "%-30s %-20s %-20s %-10s %-15s %s" % [

--- a/lib/idrac/firmware_catalog.rb
+++ b/lib/idrac/firmware_catalog.rb
@@ -162,10 +162,16 @@ module IDRAC
         category = category_node ? category_node.text.strip : ""
         
         version = component['dellVersion'] || component['vendorVersion'] || ""
-        
+
+        # Dell componentIDs this DUP actually flashes. This is the reliable key
+        # for matching a DUP to an installed component (see #check_updates) —
+        # names are ambiguous (every NIC DUP says "Ethernet"), so name-matching
+        # picks wrong DUPs and iDRAC rejects them (RED097 / "not compatible").
+        component_ids = component.xpath(".//SupportedDevices/Device/@componentID").map(&:value).uniq
+
         # Skip if missing essential information
         next if name.empty? || path.empty? || version.empty?
-        
+
         # Only include firmware updates
         if component_type.include?("Firmware") ||
            category.include?("BIOS") ||
@@ -174,13 +180,14 @@ module IDRAC
            name.include?("BIOS") ||
            name.include?("Firmware") ||
            name.include?("iDRAC")
-          
+
           updates << {
             name: name,
             version: version,
             path: path,
             component_type: component_type,
             category: category,
+            component_ids: component_ids,
             download_url: "https://downloads.dell.com/#{path}"
           }
         end
@@ -189,7 +196,35 @@ module IDRAC
       puts "Found #{updates.size} firmware updates for system ID #{system_id}"
       updates
     end
-    
+
+    # Select the catalog DUPs that apply to one installed component (`fw` from
+    # the iDRAC inventory). Matches on Dell componentID — the reliable key —
+    # and only falls back to the legacy name heuristic when the inventory
+    # didn't expose a componentID (e.g. it reports "0").
+    def updates_for_component(catalog_updates, fw)
+      component_id = fw[:component_id]
+      if component_id && component_id != "0"
+        catalog_updates.select { |u| Array(u[:component_ids]).include?(component_id) }
+      else
+        name = fw[:name] || ""
+        ids = extract_identifiers(name)
+        catalog_updates.select do |u|
+          un = u[:name] || ""
+          ids.any? { |id| un.downcase.include?(id.downcase) } ||
+            un.downcase.include?(name.downcase) ||
+            name.downcase.include?(un.downcase)
+        end
+      end
+    end
+
+    # Sortable key for a Dell version string (e.g. "25.5.9.0001", "22.00.6").
+    # Non-numeric/odd versions sort lowest rather than raising.
+    def version_key(version)
+      Gem::Version.new(version.to_s[/\d[\d.]*/] || "0")
+    rescue ArgumentError
+      Gem::Version.new("0")
+    end
+
     def extract_identifiers(name)
       return [] unless name
       

--- a/lib/idrac/firmware_catalog.rb
+++ b/lib/idrac/firmware_catalog.rb
@@ -161,7 +161,10 @@ module IDRAC
         category_node = component.xpath("./Category/Display[@lang='en']").first
         category = category_node ? category_node.text.strip : ""
         
-        version = component['dellVersion'] || component['vendorVersion'] || ""
+        # Prefer the numeric vendorVersion (e.g. "25.5.9.0001") over dellVersion,
+        # which is just the package revision label ("A17"). Comparing that label
+        # against an installed numeric version falsely flags every component.
+        version = component['vendorVersion'] || component['dellVersion'] || ""
 
         # Dell componentIDs this DUP actually flashes. This is the reliable key
         # for matching a DUP to an installed component (see #check_updates) —

--- a/lib/idrac/version.rb
+++ b/lib/idrac/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IDRAC
-  VERSION = "0.10.1"
+  VERSION = "0.10.2"
 end

--- a/spec/lib/firmware_catalog_component_id_spec.rb
+++ b/spec/lib/firmware_catalog_component_id_spec.rb
@@ -1,0 +1,93 @@
+require 'spec_helper'
+require 'idrac'
+require 'tempfile'
+
+# The catalog must match an installed component to a Dell Update Package by
+# *componentID*, not by display name. Names are ambiguous — every NIC DUP says
+# "Ethernet" — so name-matching picks the wrong DUP, which iDRAC then rejects
+# (RED097 "component not in inventory" / "DUP not compatible with the target").
+RSpec.describe IDRAC::FirmwareCatalog, 'componentID matching' do
+  # Two PERC DUPs (same componentID, different revisions) and two NICs that
+  # share the SAME display name but have DIFFERENT componentIDs.
+  let(:catalog_xml) do
+    <<~XML
+      <Manifest>
+        <SoftwareComponent dellVersion="A16" path="FOLDER_A/WRF3Y_25.5.8.EXE">
+          <Name><Display lang="en">PERC H730P Mini Controller firmware</Display></Name>
+          <ComponentType><Display lang="en">Firmware</Display></ComponentType>
+          <Category><Display lang="en">SAS RAID</Display></Category>
+          <SupportedSystems><Brand><Model systemID="0601"/></Brand></SupportedSystems>
+          <SupportedDevices><Device componentID="101560"/></SupportedDevices>
+        </SoftwareComponent>
+        <SoftwareComponent dellVersion="A17" path="FOLDER_B/700GG_25.5.9.EXE">
+          <Name><Display lang="en">PERC H730P Mini Controller firmware</Display></Name>
+          <ComponentType><Display lang="en">Firmware</Display></ComponentType>
+          <Category><Display lang="en">SAS RAID</Display></Category>
+          <SupportedSystems><Brand><Model systemID="0601"/></Brand></SupportedSystems>
+          <SupportedDevices><Device componentID="101560"/></SupportedDevices>
+        </SoftwareComponent>
+        <SoftwareComponent vendorVersion="22.00.6" path="FOLDER_C/DFF48_22.00.6.EXE">
+          <Name><Display lang="en">Broadcom Gigabit Ethernet</Display></Name>
+          <ComponentType><Display lang="en">Firmware</Display></ComponentType>
+          <Category><Display lang="en">Network</Display></Category>
+          <SupportedSystems><Brand><Model systemID="0601"/></Brand></SupportedSystems>
+          <SupportedDevices><Device componentID="27474"/></SupportedDevices>
+        </SoftwareComponent>
+        <SoftwareComponent vendorVersion="23.61.3" path="FOLDER_D/32W7Y_23.61.3.EXE">
+          <Name><Display lang="en">Broadcom Gigabit Ethernet</Display></Name>
+          <ComponentType><Display lang="en">Firmware</Display></ComponentType>
+          <Category><Display lang="en">Network</Display></Category>
+          <SupportedSystems><Brand><Model systemID="0601"/></Brand></SupportedSystems>
+          <SupportedDevices><Device componentID="99999"/></SupportedDevices>
+        </SoftwareComponent>
+      </Manifest>
+    XML
+  end
+
+  let(:catalog_file) do
+    f = Tempfile.new(['catalog', '.xml'])
+    f.write(catalog_xml)
+    f.flush
+    f
+  end
+
+  let(:catalog) { described_class.new(catalog_file.path) }
+  let(:updates) { catalog.find_updates_for_system('0601') }
+
+  after { catalog_file.close! }
+
+  it 'captures the supported componentIDs for each DUP' do
+    expect(updates.size).to eq(4)
+    expect(updates).to all(satisfy { |u| u[:component_ids].is_a?(Array) && !u[:component_ids].empty? })
+    nic = updates.find { |u| u[:path].include?('DFF48') }
+    expect(nic[:component_ids]).to eq(['27474'])
+  end
+
+  it 'matches an installed component to DUPs by componentID, ignoring same-named ones' do
+    fw = { name: 'Broadcom Gigabit Ethernet BCM5720 - B0:26:28:B3:4A:10', component_id: '27474', version: '21.81.3' }
+    matched = catalog.updates_for_component(updates, fw)
+    # Only the componentID-27474 DUP — NOT the identically-named 99999 NIC.
+    expect(matched.map { |u| u[:path] }).to eq(['FOLDER_C/DFF48_22.00.6.EXE'])
+  end
+
+  it 'picks the newest revision among several DUPs for one componentID' do
+    fw = { name: 'PERC H730P Mini', component_id: '101560', version: '25.5.8.0001' }
+    matched = catalog.updates_for_component(updates, fw)
+    expect(matched.size).to eq(2)
+    newest = matched.max_by { |u| catalog.version_key(u[:version]) }
+    expect(newest[:path]).to include('700GG') # A17 > A16
+  end
+
+  it 'falls back to name matching only when the inventory has no componentID' do
+    fw = { name: 'Broadcom Gigabit Ethernet', component_id: '0', version: '21.81.3' }
+    matched = catalog.updates_for_component(updates, fw)
+    # Without a usable componentID, name matching returns both same-named NICs.
+    expect(matched.size).to eq(2)
+  end
+
+  it 'version_key sorts Dell version strings and never raises on odd input' do
+    expect(catalog.version_key('25.5.9.0001')).to be > catalog.version_key('25.5.8.0001')
+    expect(catalog.version_key('22.00.6')).to be > catalog.version_key('21.81.3')
+    expect { catalog.version_key(nil) }.not_to raise_error
+  end
+end


### PR DESCRIPTION
## Problem

`check_updates` matched installed components to catalog DUPs by **display name** — substring match, `extract_identifiers`, or an `"Ethernet"/"Network"` keyword. Names are ambiguous (every NIC DUP says "Ethernet"), so it picked the wrong DUPs.

Observed on a PowerEdge R630 (iDRAC8):
- The **same** `Network_Firmware_40NTK` DUP was offered for **both** the 10Gb (BCM57412) and 1Gb (BCM5720) cards.
- The PERC H730P Mini (componentID `101560`) was offered DUP `NYKX7`, which doesn't support `101560`. Applying it failed with iDRAC **`RED097` — "the specified firmware image is for a component that is not in the target system inventory."**
- Version comparisons were nonsense (e.g. installed `21.85.21.92` vs an unrelated DUP's `19.5.12`), producing phantom "updates" that were actually downgrades or re-releases.

## Fix

Match by **Dell componentID** — the reliable key iDRAC itself uses:

- `find_updates_for_system` records each DUP's `SupportedDevices/Device/@componentID`.
- `get_system_inventory` records each installed component's componentID (`Oem.Dell…ComponentID`, else parsed from the `Installed-<componentID>-<version>` inventory Id).
- `check_updates` matches on componentID and picks the **newest** revision among matches. It falls back to the legacy name heuristic **only** when the inventory exposes no componentID (reported as `"0"`).

The existing `systemID` filter is untouched, so a `componentID` + `systemID` match lands the correct **and applicable** DUP. On the R630 this correctly selects `700GG` (PERC `25.5.9.0001`) and `DFF48` (BCM5720 `22.00.6`) instead of the bogus matches.

## Tests

New `spec/lib/firmware_catalog_component_id_spec.rb` proves componentID matching beats an identically-named wrong DUP, picks the newest revision, and falls back to name-matching only when no componentID is present. Full suite green (`12 examples, 0 failures` including the existing iDRAC8 firmware spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
