### PR TITLE
iDRAC8 firmware install: image URI from @odata.id + NowAndReboot

### DIFF
--- a/lib/idrac/firmware.rb
+++ b/lib/idrac/firmware.rb
@@ -526,11 +526,10 @@ module IDRAC
         end
         
         # Construct the firmware URI from the upload response
-        image_uri = if firmware_id
-          "#{http_push_uri}/#{firmware_id}"
-        else
-          upload_response.headers['Location'] || http_push_uri
-        end
+        # Prefer @odata.id from response body, then Location header, then constructed path
+        image_uri = upload_data&.dig('@odata.id') ||
+                    upload_response.headers['Location'] ||
+                    (firmware_id ? "#{http_push_uri}/#{firmware_id}" : http_push_uri)
 
         # Check if Dell OEM Install action is available (iDRAC8)
         # This is more reliable than SimpleUpdate on older iDRACs
@@ -540,9 +539,10 @@ module IDRAC
         if dell_install_target
           puts "Using Dell OEM Install action (iDRAC8)...".light_cyan
           puts "Firmware URI: #{image_uri}".light_cyan
+          # iDRAC8 DellUpdateService.Install expects @odata.id URIs
           install_payload = {
             "SoftwareIdentityURIs" => [image_uri],
-            "InstallUpon" => "Now"
+            "InstallUpon" => "NowAndReboot"
           }
           update_response = client.authenticated_request(
             :post,


### PR DESCRIPTION
## What

Two fixes to `IDRAC::Firmware#update`'s iDRAC8 install path:

1. **Image URI from the response `@odata.id`.** It was always constructed as `#{http_push_uri}/#{firmware_id}`. The authoritative URI is the `@odata.id` in the upload response body; fall back to the `Location` header, then the constructed path.
2. **`InstallUpon "NowAndReboot"`** instead of `"Now"`. `"Now"` stages the payload without applying it for components that need a reboot (BIOS, NIC, PERC), so the update silently doesn't take.

## Why

This matches the curl-based Dell OEM Install flow that works in practice against iDRAC8 (and is what the consuming app uses directly). Verified end-to-end while flashing a PERC H730P `25.5.8.0001 → 25.5.9.0001` on an R630.

Follow-up to #15 (separate concern: #15 fixed DUP *matching*; this fixes the *install* request).
